### PR TITLE
fix: replace toArray

### DIFF
--- a/src/boot/initFs.ts
+++ b/src/boot/initFs.ts
@@ -5,6 +5,7 @@ import {
   WORKING_DIR_INODE_ID_KEY,
   WORKING_DIR_KEY,
 } from '@/shell/constants';
+import { serializeDirectoryContent } from '@/systemCalls/utils/dir';
 
 export default async function initFs(tx: FsDBUpgradeTX) {
   const inodes = tx.objectStore('inodes');
@@ -58,13 +59,9 @@ export default async function initFs(tx: FsDBUpgradeTX) {
       }
     }
 
-    const directoryContentString = directoryEntries
-      .entries()
-      .toArray()
-      .map((pair) => pair.join('\t'))
-      .join('\n');
+    const directoryContentBlob = serializeDirectoryContent(directoryEntries);
 
-    return await blobs.put(new Blob([directoryContentString]), directoryBlobId);
+    return await blobs.put(directoryContentBlob, directoryBlobId);
   }
 
   const rootInodeId = await createDirectoryFromMap(initialFileMap, undefined);

--- a/src/shell/commands/ls.ts
+++ b/src/shell/commands/ls.ts
@@ -67,10 +67,11 @@ async function getEntries(
 ): Promise<GetEntriesResult> {
   try {
     const { directoryContents } = await readDirectory(await fsDB, path);
-    const entries = directoryContents
-      .keys()
-      .filter((entry) => showHidden || !entry.startsWith('.'))
-      .toArray();
+    const entries = Array.from(
+      directoryContents
+        .keys()
+        .filter((entry) => showHidden || !entry.startsWith('.'))
+    );
 
     return { status: 'success', path, entries };
   } catch (reason) {

--- a/src/shell/executeCommand.ts
+++ b/src/shell/executeCommand.ts
@@ -38,7 +38,7 @@ const cmdNameToCmd = new Map<string, Command>(
   })
 );
 
-const cmdTrie = new Trie(cmdNameToCmd.keys().toArray());
+const cmdTrie = new Trie(Array.from(cmdNameToCmd.keys()));
 
 export const executeCommand = async (
   cmd: string,

--- a/src/systemCalls/utils/dir.ts
+++ b/src/systemCalls/utils/dir.ts
@@ -19,10 +19,8 @@ export async function deserializeDirectoryContent(
 export function serializeDirectoryContent(
   directoryEntries: Map<string, number>
 ): Blob {
-  const directoryContentString = directoryEntries
-    .entries()
-    .toArray()
-    .map((pair) => pair.join('\t'))
-    .join('\n');
+  const directoryContentString = Array.from(
+    directoryEntries.entries().map((pair) => pair.join('\t'))
+  ).join('\n');
   return new Blob([directoryContentString]);
 }


### PR DESCRIPTION
`toArray` is not yet implemented in safari - [MDN link](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/toArray#browser_compatibility)